### PR TITLE
Replace log4j with slf4j and still allows for log4j fans to use log4j

### DIFF
--- a/rest-api-sample/pom.xml
+++ b/rest-api-sample/pom.xml
@@ -22,6 +22,17 @@
 			<artifactId>log4j</artifactId>
 			<version>1.2.14</version>
 		</dependency>
+		<!-- had to add these as they became optional on rest-api -->
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.1</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/rest-api-sdk/pom.xml
+++ b/rest-api-sdk/pom.xml
@@ -45,15 +45,39 @@
 			<artifactId>gson</artifactId>
 			<version>2.2.2</version>
 		</dependency>
-		<dependency>
+        <!-- BEGIN: logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.10</version>
+        </dependency>
+        <!--
+        This is the static binding for log4j 2 with slf4j, see http://www.slf4j.org/codes.html#StaticLoggerBinder
+        Projects that depend on rest-api-sdk that want to continue to use log4j will need to add this dependency.
+        To allow other projects to use other bindings this dependency was made optional.
+
+        To minimize impact on your user base, you could remove the <optional>  on the log4j dependencies and projects
+        that CANNOT use log4j would have to exclude this dependency doing something like what is described here:
+        http://www.slf4j.org/codes.html#multiple_bindings
+        -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.1</version>
+            <optional>true</optional>
+        </dependency>
+        <!-- End static binding -->
+        <dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 			<version>2.1</version>
+            <optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>2.1</version>
+            <optional>true</optional>
 		</dependency>
     </dependencies>
     <build>

--- a/rest-api-sdk/src/main/java/com/paypal/base/APIService.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/APIService.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.paypal.base.credential.CertificateCredential;
 import com.paypal.base.exception.ClientActionRequiredException;
@@ -15,6 +13,8 @@ import com.paypal.base.exception.InvalidResponseDataException;
 import com.paypal.base.exception.MissingCredentialException;
 import com.paypal.base.exception.OAuthException;
 import com.paypal.base.exception.SSLConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper class for api calls
@@ -22,7 +22,7 @@ import com.paypal.base.exception.SSLConfigurationException;
  */
 public class APIService {
 
-	private static final Logger log = LogManager.getLogger(APIService.class);
+	private static final Logger log = LoggerFactory.getLogger(APIService.class);
 	
 	/**
 	 * Service Endpoint

--- a/rest-api-sdk/src/main/java/com/paypal/base/BaseService.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/BaseService.java
@@ -8,8 +8,6 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.paypal.base.exception.ClientActionRequiredException;
 import com.paypal.base.exception.HttpErrorException;
@@ -18,14 +16,16 @@ import com.paypal.base.exception.InvalidResponseDataException;
 import com.paypal.base.exception.MissingCredentialException;
 import com.paypal.base.exception.OAuthException;
 import com.paypal.base.exception.SSLConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <code>BaseService</code> acts as base class for any concrete API service. The
  * Service class generated may extend this class to make API calls through HTTP
  */
 public abstract class BaseService {
-	
-	private static final Logger log = LogManager.getLogger(BaseService.class);
+
+	private static final Logger log = LoggerFactory.getLogger(BaseService.class);
 
 	/*
 	 * Map used for to override ConfigManager configurations

--- a/rest-api-sdk/src/main/java/com/paypal/base/GoogleAppEngineHttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/GoogleAppEngineHttpConnection.java
@@ -5,10 +5,10 @@ import java.net.HttpURLConnection;
 import java.net.Proxy;
 import java.net.URL;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.paypal.base.exception.SSLConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A special HttpConnection for use on Google App Engine.
@@ -19,8 +19,8 @@ import com.paypal.base.exception.SSLConfigurationException;
  */
 public class GoogleAppEngineHttpConnection extends HttpConnection {
 
-	private static final Logger log = LogManager.getLogger(GoogleAppEngineHttpConnection.class);
-	
+	private static final Logger log = LoggerFactory.getLogger(GoogleAppEngineHttpConnection.class);
+
 	@Override
 	public void setupClientSSL(String certPath, String certKey)
 			throws SSLConfigurationException {

--- a/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
@@ -9,13 +9,13 @@ import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.paypal.base.exception.ClientActionRequiredException;
 import com.paypal.base.exception.HttpErrorException;
 import com.paypal.base.exception.InvalidResponseDataException;
 import com.paypal.base.exception.SSLConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base HttpConnection class
@@ -23,8 +23,8 @@ import com.paypal.base.exception.SSLConfigurationException;
  */
 public abstract class HttpConnection {
 
-	private static final Logger log = LogManager.getLogger(HttpConnection.class);
-	
+	private static final Logger log = LoggerFactory.getLogger(HttpConnection.class);
+
 	/**
 	 * Subclasses must set the http configuration in the
 	 * createAndconfigureHttpConnection() method.

--- a/rest-api-sdk/src/main/java/com/paypal/base/ipn/IPNMessage.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/ipn/IPNMessage.java
@@ -8,19 +8,13 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import com.paypal.base.ConfigManager;
-import com.paypal.base.ConnectionManager;
-import com.paypal.base.Constants;
-import com.paypal.base.HttpConfiguration;
-import com.paypal.base.HttpConnection;
-import com.paypal.base.SDKUtil;
+import com.paypal.base.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IPNMessage {
 
-	private static final Logger log = LogManager.getLogger(IPNMessage.class);
+	private static final Logger log = LoggerFactory.getLogger(BaseService.class);
 	
 	private static final long serialVersionUID = -7187275404183441828L;
 	private static final String ENCODING = "windows-1252";

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/PayPalResource.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/PayPalResource.java
@@ -9,8 +9,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.paypal.base.APICallPreHandler;
 import com.paypal.base.ConfigManager;
@@ -20,13 +18,15 @@ import com.paypal.base.HttpConfiguration;
 import com.paypal.base.HttpConnection;
 import com.paypal.base.SDKUtil;
 import com.paypal.base.SDKVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * PayPalResource acts as a base class for REST enabled resources.
  */
 public abstract class PayPalResource extends PayPalModel{
 
-	private static final Logger log = LogManager.getLogger(PayPalResource.class);
+	private static final Logger log = LoggerFactory.getLogger(PayPalResource.class);
 	
 	/*
 	 * The class relies on an implementation of APICallPreHandler (here


### PR DESCRIPTION
This change replaces the direct use of log4j with the use of slf4j on the rest-api-sdk module.

Users who still want to use log4j2 just need to add a dependency

```xml
        <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-slf4j-impl</artifactId>
            <version>2.1</version>
        </dependency>
```

users who want to use j.u.l can add

```xml
        <dependency>
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-jdk14</artifactId>
            <version>1.7.10</version>
        </dependency>
```

If a user doesn't add a static binding, he will be faced with the following self explaining message:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

There are implementations for all well-known logging frameworks, check: http://repo2.maven.org/maven2/org/slf4j/

This will make all the users that complained in paypal/PayPal-Java-SDK#63 very happy!