### PR TITLE
Fixes update() in CreditCard

### DIFF
--- a/rest-api-sdk/src/main/java/com/paypal/api/payments/CreditCard.java
+++ b/rest-api-sdk/src/main/java/com/paypal/api/payments/CreditCard.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gson.GsonBuilder;
 import com.paypal.base.Constants;
 import com.paypal.base.rest.APIContext;
 import com.paypal.base.rest.HttpMethod;
@@ -462,12 +463,14 @@ public class CreditCard  extends PayPalResource {
 	 * Update information in a previously saved card. Only the modified fields need to be passed in the request.
 	 * @param accessToken
 	 *            Access Token used for the API call.
+	 * @param patchRequest
+	 *            PatchRequest
 	 * @return CreditCard
 	 * @throws PayPalRESTException
 	 */
-	public CreditCard update(String accessToken) throws PayPalRESTException {
+	public CreditCard update(String accessToken, List<Patch> patchRequest) throws PayPalRESTException {
 		APIContext apiContext = new APIContext(accessToken);
-		return update(apiContext);
+		return update(apiContext, patchRequest);
 	}
 
 	/**
@@ -477,7 +480,7 @@ public class CreditCard  extends PayPalResource {
 	 * @return CreditCard
 	 * @throws PayPalRESTException
 	 */
-	public CreditCard update(APIContext apiContext) throws PayPalRESTException {
+	public CreditCard update(APIContext apiContext, List<Patch> patchRequest) throws PayPalRESTException {
 		if (apiContext == null) {
 			throw new IllegalArgumentException("APIContext cannot be null");
 		}
@@ -492,10 +495,13 @@ public class CreditCard  extends PayPalResource {
 		if (this.getId() == null) {
 			throw new IllegalArgumentException("Id cannot be null");
 		}
+		if (patchRequest == null) {
+			throw new IllegalArgumentException("patchRequest cannot be null");
+		}
 		Object[] parameters = new Object[] {this.getId()};
 		String pattern = "v1/vault/credit-card/{0}";
 		String resourcePath = RESTUtil.formatURIPath(pattern, parameters);
-		String payLoad = this.toJSON();
+		String payLoad = new GsonBuilder().create().toJson(patchRequest);
 		return configureAndExecute(apiContext, HttpMethod.PATCH, resourcePath, payLoad, CreditCard.class);
 	}
 

--- a/rest-api-sdk/src/test/java/com/paypal/api/payments/CreditCardTestCase.java
+++ b/rest-api-sdk/src/test/java/com/paypal/api/payments/CreditCardTestCase.java
@@ -165,7 +165,34 @@ public class CreditCardTestCase {
 				+ retrievedCreditCard.getState());
 
 	}
-	
+
+	@Test(groups = "integration", dependsOnMethods = { "createCreditCardTest" })
+	public void updateCreditCard() throws PayPalRESTException {
+		logger.info("**** Update CreditCard ****");
+		logger.info("Generated Access Token = " + TokenHolder.accessToken);
+
+		int newMonth = 12;
+		Patch patch = new Patch("replace", "/expire_month");
+		patch.setValue(new Integer(newMonth));
+
+		List<Patch> patchRequest = new ArrayList<Patch>();
+		patchRequest.add(patch);
+
+		// execute update
+		CreditCard card = new CreditCard();
+		card.setId(createdCreditCardId);
+
+		CreditCard retrievedCreditCard = card.update(TokenHolder.accessToken, patchRequest);
+		logger.info("Request = " + CreditCard.getLastRequest());
+		logger.info("Response = " + CreditCard.getLastResponse());
+		Assert.assertEquals(
+				retrievedCreditCard.getExpireMonth(),
+				newMonth);
+		logger.info("Retrieved Credit Card status = "
+				+ retrievedCreditCard.getState());
+
+	}
+
 	@Test(groups = "integration", dependsOnMethods = { "getCreditCard" })
 	public void deleteCreditCard() throws PayPalRESTException {
 		logger.info("**** Delete CreditCard ****");


### PR DESCRIPTION
Updated payload format sent to PayPal in `CreditCard.update()`. It works in a similar fashion to `Plan.update()` - it takes a `List<Patch>`, serializes it and sends to the server.
Also, adds a credit card update test that was missing previously.

Fixes #106 