### PR TITLE
Version of com.paypal.sdk:rest-api-sdk updated.

### DIFF
--- a/rest-api-sample/pom.xml
+++ b/rest-api-sample/pom.xml
@@ -10,7 +10,7 @@
 		<dependency>
 			<groupId>com.paypal.sdk</groupId>
 			<artifactId>rest-api-sdk</artifactId>
-			<version>1.2.1</version>
+			<version>1.2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>


### PR DESCRIPTION
The version of the com.paypal.sdk:rest-api-sdk library of the rest-api-sample pom.xml is statically set to 1.2.1.
It needs at least the version 1.2.4 of the library to compile successfully.