### PR TITLE
Update slf4j

### DIFF
--- a/rest-api-sdk/pom.xml
+++ b/rest-api-sdk/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.10</version>
+            <version>1.7.13</version>
         </dependency>
         <!--
         This is the static binding for log4j 2 with slf4j, see http://www.slf4j.org/codes.html#StaticLoggerBinder


### PR DESCRIPTION
slf4j versions 1.7.9-1.7.12 had an issue with an `AccessControlException`, according to [this SO answer](http://stackoverflow.com/a/33637960/1836506).  I encountered it when using the PayPal SDK in Google App Engine.  Explicitly requiring the most recent version of slf4j in my `pom.xml` fixed the error.