### PR TITLE
Custom SSLContext on ConnectionManager fix

### DIFF
--- a/rest-api-sdk/src/main/java/com/paypal/base/ConnectionManager.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/ConnectionManager.java
@@ -40,11 +40,11 @@ public final class ConnectionManager {
 	 * @return HttpConnection object
 	 */
 	public HttpConnection getConnection() {
-    	if(customSslContext != null) {
-    	    return new DefaultHttpConnection(customSslContext);
-    	} else {
-    	    return new DefaultHttpConnection();
-    	}
+    		if(customSslContext != null) {
+			return new DefaultHttpConnection(customSslContext);
+    		} else {
+			return new DefaultHttpConnection();
+    		}
 	}
 
 	/**
@@ -55,7 +55,6 @@ public final class ConnectionManager {
 	 * @return {@link HttpConnection} object
 	 */
 	public HttpConnection getConnection(HttpConfiguration httpConfig) {
-
 		if (httpConfig.isGoogleAppEngine()) {
 			return new GoogleAppEngineHttpConnection();
 		} else {

--- a/rest-api-sdk/src/main/java/com/paypal/base/ConnectionManager.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/ConnectionManager.java
@@ -59,7 +59,7 @@ public final class ConnectionManager {
 		if (httpConfig.isGoogleAppEngine()) {
 			return new GoogleAppEngineHttpConnection();
 		} else {
-			return new DefaultHttpConnection();
+			return getConnection();
 		}
 	}
 	

--- a/rest-api-sdk/src/test/java/com/paypal/base/ConnectionManagerTest.java
+++ b/rest-api-sdk/src/test/java/com/paypal/base/ConnectionManagerTest.java
@@ -1,7 +1,5 @@
 package com.paypal.base;
 
-import javax.net.ssl.SSLContext;
-
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -37,10 +35,12 @@ public class ConnectionManagerTest {
 		Assert.assertEquals(conn.getConnection(httpConfig).getClass(),
 				DefaultHttpConnection.class);
 		
-		conn.configureCustomSslContext(SSLContext.getDefault());
+		conn.configureCustomSslContext(SSLUtil.getSSLContext(null));
 		
 		Assert.assertEquals(conn.getConnection(httpConfig).getClass(),
 			DefaultHttpConnection.class);
+		
+		conn.configureCustomSslContext(null);
 	}
 
 	@AfterClass


### PR DESCRIPTION
Related to PR #144 and to issue #143 where I made a change that lets you configure a custom SSLContext to the ConnectionManager.

Well, I forgot to commit to that PR a very important change. In fact, without this change, that PR made no difference because many payments calls uses another method.

It worked on our environment because an deploy that I've made to our maven repository before de the pull request creation. Now that I've updated to v1.4.2, the custom SSLContext is not being acessed anymore because this missing change.

Sorry :)