### PR TITLE
Enabled Custom Headers to All Calls

### DIFF
--- a/rest-api-sample/src/main/java/com/paypal/api/payments/util/GenerateAccessToken.java
+++ b/rest-api-sample/src/main/java/com/paypal/api/payments/util/GenerateAccessToken.java
@@ -1,5 +1,7 @@
 package com.paypal.api.payments.util;
 
+import java.util.Map;
+
 import com.paypal.base.ConfigManager;
 import com.paypal.base.Constants;
 import com.paypal.base.rest.OAuthTokenCredential;
@@ -18,6 +20,20 @@ public class GenerateAccessToken {
 				Constants.CLIENT_SECRET);
 
 		return new OAuthTokenCredential(clientID, clientSecret)
+				.getAccessToken();
+	}
+	
+	public static String getAccessToken(Map<String, String> headers) throws PayPalRESTException {
+
+		// ###AccessToken
+		// Retrieve the access token from
+		// OAuthTokenCredential by passing in
+		// ClientID and ClientSecret
+		String clientID = ConfigManager.getInstance().getValue(Constants.CLIENT_ID);
+		String clientSecret = ConfigManager.getInstance().getValue(
+				Constants.CLIENT_SECRET);
+
+		return new OAuthTokenCredential(clientID, clientSecret).setHeaders(headers)
 				.getAccessToken();
 	}
 }

--- a/rest-api-sdk/src/main/java/com/paypal/base/BaseAPIContext.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/BaseAPIContext.java
@@ -1,5 +1,6 @@
 package com.paypal.base;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.paypal.base.message.XMLMessageSerializer;
@@ -28,6 +29,19 @@ public class BaseAPIContext {
 	 */
 	public void setHTTPHeaders(Map<String, String> httpHeaders) {
 		HTTPHeaders = httpHeaders;
+	}
+	
+	/**
+	 * @param httpHeaders the httpHeaders to set
+	 */
+	public void addHTTPHeaders(Map<String, String> httpHeaders) {
+		if (HTTPHeaders == null) {
+			HTTPHeaders = new HashMap<String, String>();
+		}
+		for (Map.Entry<String, String> entry : httpHeaders.entrySet())
+		{
+		    HTTPHeaders.put(entry.getKey(), entry.getValue());
+		}
 	}
 
 	/**

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
@@ -62,6 +62,11 @@ public final class OAuthTokenCredential implements ICredential {
 	 * Access Token that is generated
 	 */
 	private String accessToken;
+	
+	/**
+	 * Headers
+	 */
+	private Map<String, String> headers;
 
 	/**
 	 * Lifetime in seconds of the access token
@@ -124,6 +129,17 @@ public final class OAuthTokenCredential implements ICredential {
 		this.clientSecret = clientSecret;
 		this.configurationMap = SDKUtil.combineDefaultMap(configurationMap);
 		this.sdkVersion = new SDKVersionImpl();
+	}
+	
+	/**
+	 * Sets Headers to Oauth Calls
+	 * 
+	 * @param headers
+	 * @return {@link OAuthTokenCredential}
+	 */
+	public OAuthTokenCredential setHeaders(Map<String, String> headers) {
+		this.headers = headers;
+		return this;
 	}
 
 	/**
@@ -199,19 +215,21 @@ public final class OAuthTokenCredential implements ICredential {
 			connection = ConnectionManager.getInstance().getConnection();
 			httpConfiguration = getOAuthHttpConfiguration();
 			connection.createAndconfigureHttpConnection(httpConfiguration);
-			Map<String, String> headers = new HashMap<String, String>();
-			headers.put(Constants.AUTHORIZATION_HEADER, "Basic "
+			if (this.headers == null) {
+				this.headers = new HashMap<String, String>();
+			}
+			this.headers.put(Constants.AUTHORIZATION_HEADER, "Basic "
 					+ base64ClientID);
 
 			// Accept only json output
-			headers.put(Constants.HTTP_ACCEPT_HEADER,
+			this.headers.put(Constants.HTTP_ACCEPT_HEADER,
 					Constants.HTTP_CONTENT_TYPE_JSON);
-			headers.put(Constants.HTTP_CONTENT_TYPE_HEADER,
+			this.headers.put(Constants.HTTP_CONTENT_TYPE_HEADER,
 					Constants.HTTP_CONFIG_DEFAULT_CONTENT_TYPE);
 			UserAgentHeader userAgentHeader = new UserAgentHeader(
 					sdkVersion != null ? sdkVersion.getSDKId() : null,
 					sdkVersion != null ? sdkVersion.getSDKVersion() : null);
-			headers.putAll(userAgentHeader.getHeader());
+			this.headers.putAll(userAgentHeader.getHeader());
 			String postRequest = getRequestPayload();
 			
 			// log request
@@ -220,12 +238,12 @@ public final class OAuthTokenCredential implements ICredential {
 				log.warn("Log level cannot be set to DEBUG in " + Constants.LIVE + " mode. Skipping request/response logging...");
 			} 
 			if (!Constants.LIVE.equalsIgnoreCase(mode)) {
-				log.debug("request header: " + headers.toString());
+				log.debug("request header: " + this.headers.toString());
 				log.debug("request body: " + postRequest);
 			}
 			
 			// send request and get & log response
-			String jsonResponse = connection.execute("", postRequest, headers);
+			String jsonResponse = connection.execute("", postRequest, this.headers);
 			if (!Constants.LIVE.equalsIgnoreCase(mode)) {
 				log.debug("response header: " + connection.getResponseHeaderMap().toString());
 				log.debug("response: " + jsonResponse.toString());
@@ -305,5 +323,7 @@ public final class OAuthTokenCredential implements ICredential {
 						.get(Constants.GOOGLE_APP_ENGINE)));
 		return httpConfiguration;
 	}
+
+	
 
 }


### PR DESCRIPTION
- Enables adding custom headers.
- Requires to set headers map to two places, because of how it is designed.
- Requires major refactoring to improvise on this.

Example:

```java
        Map<String, String> headers = new HashMap<String, String>();
        headers.put("Custom-Header", "Value");

        // Use `setHeaders` function to set custom header to OAuth Calls
        TokenHolder.accessToken = new OAuthTokenCredential(clientID,
				clientSecret).setHeaders(headers).getAccessToken();
        ...
        ...
        APIContext apiContext = new APIContext(TokenHolder.accessToken);
        // Use `addHTTPHeaders` in ApiContext object to set custom headers for API Calls
        apiContext.addHTTPHeaders(headers);

```