### PR TITLE
Remove loading hardcoded config file from API

### DIFF
--- a/rest-api-sample/src/main/java/com/paypal/api/sample/FuturePaymentSample.java
+++ b/rest-api-sample/src/main/java/com/paypal/api/sample/FuturePaymentSample.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.paypal.base.rest.PayPalResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -75,7 +76,7 @@ public class FuturePaymentSample {
 
 	public static void main(String[] args) {
 		try {
-			
+
 			String authorizationCode = "";
 			String correlationId = "";
 			for (int i = 0; i < args.length; ++i) {
@@ -88,7 +89,9 @@ public class FuturePaymentSample {
 			}
 
 			FuturePaymentSample fps = new FuturePaymentSample();
+			PayPalResource.initConfig(fps.getClass().getClassLoader().getResourceAsStream("sdk_config.properties"));
 			Payment payment = fps.create(correlationId, authorizationCode);
+			System.out.println(Payment.getLastResponse());
 		} catch (Exception e) {
 			e.printStackTrace();
 			System.out.println(Payment.getLastRequest());

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/PayPalResource.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/PayPalResource.java
@@ -3,7 +3,6 @@ package com.paypal.base.rest;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -225,7 +224,7 @@ public abstract class PayPalResource extends PayPalModel{
 	 *            {@link APIContext} to be used for the call.
 	 * @param httpMethod
 	 *            Http Method verb
-	 * @param resource
+	 * @param resourcePath
 	 *            Resource URI path
 	 * @param payLoad
 	 *            Payload to Service
@@ -453,8 +452,6 @@ public abstract class PayPalResource extends PayPalModel{
 	 *            Configuration to base the construction upon.
 	 * @param httpMethod
 	 *            HTTP Method
-	 * @param contentType
-	 *            Content-Type header
 	 * @param apiCallPreHandler
 	 *            {@link APICallPreHandler} for retrieving EndPoint
 	 * @return
@@ -493,21 +490,17 @@ public abstract class PayPalResource extends PayPalModel{
 				.get(Constants.DEVICE_IP_ADDRESS));
 		return httpConfiguration;
 	}
-	
-	public ClientCredentials getClientCredential() throws FileNotFoundException, IOException {
+
+	/**
+	 * Returns ClientCredentials with client id and client secret from configuration Map
+	 *
+	 * @return Client credentials
+     */
+	public static ClientCredentials getClientCredential() {
 		ClientCredentials credentials = new ClientCredentials();
-		Properties properties = getCredential();
-		credentials.setClientID(properties.getProperty(Constants.CLIENT_ID));
-		credentials.setClientSecret(properties.getProperty(Constants.CLIENT_SECRET));
+		credentials.setClientID(configurationMap.get(Constants.CLIENT_ID));
+		credentials.setClientSecret(configurationMap.get(Constants.CLIENT_SECRET));
 		return credentials;
-	}
-	
-	
-	private Properties getCredential() throws FileNotFoundException, IOException {
-		Properties properties = new Properties();
-		properties.load(new FileReader(new File(".",
-				"src/main/resources/sdk_config.properties")));
-		return properties;
 	}
 
 }

--- a/rest-api-sdk/src/test/java/com/paypal/base/rest/PayPalResourceTestCase.java
+++ b/rest-api-sdk/src/test/java/com/paypal/base/rest/PayPalResourceTestCase.java
@@ -6,6 +6,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 
+import com.paypal.base.ClientCredentials;
+import com.paypal.base.Constants;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -44,6 +46,27 @@ public class PayPalResourceTestCase {
 			FileInputStream fis = new FileInputStream(testFile);
 			props.load(fis);
 			PayPalResource.initConfig(props);
+		} catch (FileNotFoundException e) {
+			Assert.fail("[sdk_config.properties] file is not available");
+		} catch (IOException e) {
+			Assert.fail("[sdk_config.properties] file is not loaded into properties");
+		}
+	}
+
+	@Test
+	public void testClientCredentials() {
+		try {
+			// Init configuration from file
+			File testFile = new File(getClass().getClassLoader().getResource("sdk_config.properties").getFile());
+			Properties props = new Properties();
+			FileInputStream fis = new FileInputStream(testFile);
+			props.load(fis);
+			PayPalResource.initConfig(props);
+
+			// Check if ClientCredentials is constructed correctly
+			ClientCredentials clientCredentials = PayPalResource.getClientCredential();
+			Assert.assertEquals(props.getProperty(Constants.CLIENT_ID), clientCredentials.getClientID());
+			Assert.assertEquals(props.getProperty(Constants.CLIENT_SECRET), clientCredentials.getClientSecret());
 		} catch (FileNotFoundException e) {
 			Assert.fail("[sdk_config.properties] file is not available");
 		} catch (IOException e) {


### PR DESCRIPTION
I saw it in recent commits. I think it is not really wise to load hardcoded config file in API class. I guess users are not obligated to put their config with given name in given path. Also added unit test to prove its working.

Let me know what you think, thanks!