### PR TITLE
Improve and unify samples

### DIFF
--- a/rest-api-sample/src/main/java/com/paypal/api/sample/InvoiceSample.java
+++ b/rest-api-sample/src/main/java/com/paypal/api/sample/InvoiceSample.java
@@ -23,10 +23,7 @@ import com.paypal.base.rest.PayPalRESTException;
  * https://developer.paypal.com/webapps/developer/docs/api/#invoicing
  *
  */
-public class InvoiceSample {
-
-	private Invoice invoice = null;
-	private String accessToken = null;
+public class InvoiceSample extends SampleBase<Invoice> {
 
 	/**
 	 * Initialize and instantiate an Invoice object
@@ -37,34 +34,7 @@ public class InvoiceSample {
 	 */
 	public InvoiceSample() throws PayPalRESTException, JsonSyntaxException,
 			JsonIOException, FileNotFoundException {
-
-		// initialize Invoice with credentials. User credentials must be stored
-		// in the file
-		Invoice.initConfig(new File(".",
-						"src/main/resources/sdk_config.properties"));
-
-		// get an access token
-		accessToken = GenerateAccessToken.getAccessToken();
-	}
-	
-	private static Invoice loadInvoice(String jsonFile) {
-	    try {
-		    BufferedReader br = new BufferedReader(new FileReader("src/main/resources/" + jsonFile));
-	        StringBuilder sb = new StringBuilder();
-	        String line = br.readLine();
-
-	        while (line != null) {
-	            sb.append(line);
-	            sb.append(System.getProperty("line.separator"));
-	            line = br.readLine();
-	        }
-	        br.close();
-	        return JSONFormatter.fromJSON(sb.toString(), Invoice.class);
-	        
-	    } catch (IOException e) {
-	    	e.printStackTrace();
-	    	return new Invoice();
-	    }
+		super(new Invoice());
 	}
 
 	/**
@@ -75,11 +45,11 @@ public class InvoiceSample {
 	 * @return newly created Invoice instance
 	 * @throws PayPalRESTException
 	 */
-	public Invoice create() throws PayPalRESTException {
+	public Invoice create() throws PayPalRESTException, IOException {
 		// populate Invoice object that we are going to play with
-		invoice = loadInvoice("invoice_create.json");
-		invoice = invoice.create(accessToken);
-		return invoice;
+		super.instance = load("invoice_create.json", Invoice.class);
+		super.instance = super.instance.create(accessToken);
+		return super.instance;
 	}
 
 	/**
@@ -90,7 +60,7 @@ public class InvoiceSample {
 	 * @throws PayPalRESTException
 	 */
 	public void send() throws PayPalRESTException {
-		invoice.send(accessToken);
+		super.instance.send(accessToken);
 	}
 
 	/**
@@ -101,12 +71,12 @@ public class InvoiceSample {
 	 * @return updated Invoice instance
 	 * @throws PayPalRESTException
 	 */
-	public Invoice update() throws PayPalRESTException {
-		String id = invoice.getId();
-		invoice = loadInvoice("invoice_update.json");
-		invoice.setId(id);
-		invoice = invoice.update(accessToken);
-		return invoice;
+	public Invoice update() throws PayPalRESTException, IOException {
+		String id = super.instance.getId();
+		super.instance = load("invoice_update.json", Invoice.class);
+		super.instance.setId(id);
+		super.instance = super.instance.update(accessToken);
+		return super.instance;
 	}
 
 	/**
@@ -118,8 +88,8 @@ public class InvoiceSample {
 	 * @throws PayPalRESTException
 	 */
 	public Invoice retrieve() throws PayPalRESTException {
-		invoice = Invoice.get(accessToken, invoice.getId());
-		return invoice;
+		super.instance = Invoice.get(accessToken, super.instance.getId());
+		return super.instance;
 	}
 
 	/**
@@ -149,7 +119,7 @@ public class InvoiceSample {
 		search.setPage(1);
 		search.setPageSize(20);
 		search.setTotalCountRequired(true);
-		return invoice.search(accessToken, search);
+		return super.instance.search(accessToken, search);
 	}
 
 	/**
@@ -164,7 +134,7 @@ public class InvoiceSample {
 		notification.setSubject("Past due");
 		notification.setNote("Please pay soon");
 		notification.setSendToMerchant(true);
-		invoice.remind(accessToken, notification);
+		super.instance.remind(accessToken, notification);
 	}
 
 	/**
@@ -180,7 +150,7 @@ public class InvoiceSample {
 		cancelNotification.setNote("Canceling invoice");
 		cancelNotification.setSendToMerchant(true);
 		cancelNotification.setSendToPayer(true);
-		invoice.cancel(accessToken, cancelNotification);
+		super.instance.cancel(accessToken, cancelNotification);
 	}
 
 	/**
@@ -190,7 +160,7 @@ public class InvoiceSample {
 	 * 
 	 * @throws PayPalRESTException
 	 */
-	public void delete() throws PayPalRESTException {
+	public void delete() throws PayPalRESTException, IOException {
 		Invoice newInvoice = this.create();
 		newInvoice.delete(accessToken);
 	}
@@ -229,6 +199,8 @@ public class InvoiceSample {
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 		} catch (PayPalRESTException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}

--- a/rest-api-sample/src/main/java/com/paypal/api/sample/SampleBase.java
+++ b/rest-api-sample/src/main/java/com/paypal/api/sample/SampleBase.java
@@ -8,37 +8,33 @@ import java.io.IOException;
 
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
-import com.paypal.api.payments.util.GenerateAccessToken;
 import com.paypal.base.rest.JSONFormatter;
+import com.paypal.base.rest.OAuthTokenCredential;
 import com.paypal.base.rest.PayPalRESTException;
 import com.paypal.base.rest.PayPalResource;
 
 public class SampleBase<T> {
 
-	protected T instance;
+	protected T instance = null;
 	protected String accessToken = null;
 
 	/**
 	 * Initialize sample base
 	 *
-	 * @param type
 	 * @throws PayPalRESTException
 	 * @throws JsonSyntaxException
 	 * @throws JsonIOException
 	 * @throws FileNotFoundException
 	 */
-	public SampleBase(T type) throws PayPalRESTException, JsonSyntaxException,
+	public SampleBase(T instance) throws PayPalRESTException, JsonSyntaxException,
 			JsonIOException, FileNotFoundException {
-
-		instance = type;
+		this.instance = instance;
 
 		// initialize sample credentials. User credentials must be stored
 		// in the file
-		PayPalResource.initConfig(new File(
+		OAuthTokenCredential tokenCredential = PayPalResource.initConfig(new File(
 				getClass().getClassLoader().getResource("sdk_config.properties").getFile()));
-
-		// get an access token
-		accessToken = GenerateAccessToken.getAccessToken();
+		this.accessToken = tokenCredential.getAccessToken();
 	}
 
 	protected <T> T load(String jsonFile, Class<T> clazz) throws IOException {

--- a/rest-api-sample/src/main/java/com/paypal/api/sample/SubscriptionSample.java
+++ b/rest-api-sample/src/main/java/com/paypal/api/sample/SubscriptionSample.java
@@ -27,7 +27,7 @@ public class SubscriptionSample extends SampleBase<Plan> {
 	 */
 	public Plan create() throws PayPalRESTException, IOException {
 		// populate Plan object that we are going to play with
-		super.instance = super.load("billingplan_create.json", instance.getClass());
+		super.instance = super.load("billingplan_create.json", Plan.class);
 		super.instance = super.instance.create(accessToken);
 		return super.instance;
 	}

--- a/rest-api-sample/src/main/java/com/paypal/api/sample/ThirdPartyInvoice.java
+++ b/rest-api-sample/src/main/java/com/paypal/api/sample/ThirdPartyInvoice.java
@@ -1,11 +1,9 @@
 package com.paypal.api.sample;
 
-import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 
+import com.paypal.base.rest.PayPalResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -16,14 +14,11 @@ import com.paypal.api.openidconnect.Tokeninfo;
 import com.paypal.api.payments.Invoice;
 import com.paypal.api.payments.Payment;
 import com.paypal.base.ClientCredentials;
-import com.paypal.base.rest.JSONFormatter;
 import com.paypal.base.rest.PayPalRESTException;
 
-public class ThirdPartyInvoice {
+public class ThirdPartyInvoice extends SampleBase<Invoice> {
 
-	private Invoice invoice = null;
 	private static final Logger log = LogManager.getLogger(ThirdPartyInvoice.class);
-	private String accessToken = null;
 
 	/**
 	 * Initialize and instantiate an Invoice object
@@ -34,31 +29,7 @@ public class ThirdPartyInvoice {
 	 * @throws FileNotFoundException
 	 */
 	public ThirdPartyInvoice() throws PayPalRESTException, JsonSyntaxException, JsonIOException, FileNotFoundException {
-
-		// initialize Invoice with credentials. User credentials must be stored
-		// in the file
-		Invoice.initConfig(new File(".", "src/main/resources/sdk_config.properties"));
-
-	}
-
-	private static Invoice loadInvoice(String jsonFile) {
-		try {
-			BufferedReader br = new BufferedReader(new FileReader("src/main/resources/" + jsonFile));
-			StringBuilder sb = new StringBuilder();
-			String line = br.readLine();
-
-			while (line != null) {
-				sb.append(line);
-				sb.append(System.getProperty("line.separator"));
-				line = br.readLine();
-			}
-			br.close();
-			return JSONFormatter.fromJSON(sb.toString(), Invoice.class);
-
-		} catch (IOException e) {
-			e.printStackTrace();
-			return new Invoice();
-		}
+		super(new Invoice());
 	}
 
 	/**
@@ -72,12 +43,11 @@ public class ThirdPartyInvoice {
 	 */
 	public Invoice create(String refreshToken) throws PayPalRESTException, FileNotFoundException, IOException {
 		Tokeninfo tokeninfo = null;
-		invoice = new Invoice();
 		log.info("creating third party invoice using refresh token " + refreshToken);
 
 		// Setup the refresh token params. This will be used to get access token
 		// from refresh token
-		ClientCredentials credentials = invoice.getClientCredential();
+		ClientCredentials credentials = super.instance.getClientCredential();
 		CreateFromRefreshTokenParameters params = new CreateFromRefreshTokenParameters();
 		params.setClientID(credentials.getClientID());
 		params.setClientSecret(credentials.getClientSecret());
@@ -95,9 +65,9 @@ public class ThirdPartyInvoice {
 		System.out.println("Generated access token from auth code: " + tokeninfo.getAccessToken());
 
 		// populate Invoice object that we are going to play with
-		invoice = loadInvoice("invoice_create.json");
-		invoice = invoice.create(accessToken);
-		return invoice;
+		super.instance = load("invoice_create.json", Invoice.class);
+		super.instance = super.instance.create(accessToken);
+		return super.instance;
 	}
 
 	public Invoice send(Invoice invoice) throws PayPalRESTException {

--- a/rest-api-sample/src/main/resources/invoice_create.json
+++ b/rest-api-sample/src/main/resources/invoice_create.json
@@ -1,6 +1,6 @@
 {
   "merchant_info": {
-    "email": "developer@sample.com",
+    "email": "jaypatel512-facilitator@hotmail.com",
     "first_name": "Dennis",
     "last_name": "Doctor",
     "business_name": "Medical Professionals, LLC",

--- a/rest-api-sample/src/main/resources/invoice_update.json
+++ b/rest-api-sample/src/main/resources/invoice_update.json
@@ -3,12 +3,12 @@
   "number": "12345",
   "status": "DRAFT",
   "merchant_info": {
-    "email": "dennis@sample.com",
+    "email": "jaypatel512-facilitator@hotmail.com",
     "first_name": "Dennis",
     "last_name": "Doctor",
     "business_name": "Medical Professionals, LLC",
     "phone": {
-      "country_code": "US",
+      "country_code": "001",
       "national_number": "5032141716"
     },
     "address": {
@@ -52,7 +52,7 @@
   ],
   "invoice_date": "2014-01-07 PST",
   "payment_term": {
-    "term_type": "NO_DUE_DATE"
+    "term_type": "DUE_ON_RECEIPT"
   },
   "tax_calculated_after_discount": false,
   "tax_inclusive": false,


### PR DESCRIPTION
What I did here:

* Unify samples with SampleBase as i was asked here https://github.com/paypal/PayPal-Java-SDK/pull/177
* Fix invoice_update.json file from Invoice samples, because country_code has to be number and term_type was not allowed according to https://developer.paypal.com/docs/api/#paymentterm-object
I did change merchant's email to the one from invoice_create.json

All samples seems to work, but I am not sure about one thing. SubscriptionSample and ThirdPartyInvoice work out of box, but Invoice sample doesn't work with given settings because of merchant's email. AFAIK it is connected with this issue https://github.com/paypal/PayPal-Python-SDK/issues/74 when i changed it to my Buisness dev account everything worked like it should, otherwise we receive Authorization error. Is it a problem? 