### PR TITLE
Better OpenID integration

### DIFF
--- a/rest-api-sdk/src/main/java/com/paypal/api/openidconnect/Tokeninfo.java
+++ b/rest-api-sdk/src/main/java/com/paypal/api/openidconnect/Tokeninfo.java
@@ -155,7 +155,8 @@ public class Tokeninfo extends PayPalResource {
 	}
 
 	/**
-	 * Creates an Access Token from an Authorization Code.
+	 * @deprecated Please use {@link #createFromAuthorizationCode(APIContext, String)} instead.
+	 * There is no more need for passing clientId and secret in the params object anymore.
 	 * 
 	 * @param createFromAuthorizationCodeParameters
 	 *            Query parameters used for API call
@@ -170,7 +171,8 @@ public class Tokeninfo extends PayPalResource {
 	}
 
 	/**
-	 * Creates an Access Token from an Authorization Code.
+	 * @deprecated Please use {@link #createFromAuthorizationCode(APIContext, String)} instead.
+	 * There is no more need for passing clientId and secret in the params object anymore.
 	 * 
 	 * @param apiContext
 	 *            {@link APIContext} to be used for the call.
@@ -187,6 +189,29 @@ public class Tokeninfo extends PayPalResource {
 		Object[] parameters = new Object[] { createFromAuthorizationCodeParameters };
 		String resourcePath = RESTUtil.formatURIPath(pattern, parameters);
 		return createFromAuthorizationCodeParameters(apiContext, createFromAuthorizationCodeParameters, resourcePath);
+	}
+
+	/**
+	 * Creates an Access Token from an Authorization Code.
+	 *
+	 * @param apiContext
+	 *            {@link APIContext} to be used for the call.
+	 * @param code
+	 *            Code returned from PayPal redirect.
+	 * @return Tokeninfo
+	 * @throws PayPalRESTException
+	 */
+	public static Tokeninfo createFromAuthorizationCode(
+			APIContext apiContext, String code)
+			throws PayPalRESTException {
+		String pattern = "v1/identity/openidconnect/tokenservice?grant_type={0}&code={1}&redirect_uri={2}";
+		CreateFromAuthorizationCodeParameters params = new CreateFromAuthorizationCodeParameters();
+		params.setClientID(apiContext.getClientID());
+		params.setClientSecret(apiContext.getClientSecret());
+		params.setCode(code);
+		Object[] parameters = new Object[] { params };
+		String resourcePath = RESTUtil.formatURIPath(pattern, parameters);
+		return createFromAuthorizationCodeParameters(apiContext, params, resourcePath);
 	}
 
 	/**

--- a/rest-api-sdk/src/main/java/com/paypal/api/payments/Invoice.java
+++ b/rest-api-sdk/src/main/java/com/paypal/api/payments/Invoice.java
@@ -532,12 +532,6 @@ public class Invoice extends PayPalResource {
 	 * @throws PayPalRESTException
 	 */
 	public static String fetchRefreshToken(APIContext context, String authorizationCode) throws PayPalRESTException {
-		CreateFromAuthorizationCodeParameters params = new CreateFromAuthorizationCodeParameters();
-		params.setClientID(context.getClientID());
-		params.setClientSecret(context.getClientSecret());
-		params.setCode(authorizationCode);
-		params.setGrantType("authorization_code");
-		Tokeninfo info = Tokeninfo.createFromAuthorizationCode(context, params);
-		return info.getRefreshToken();
+		return Tokeninfo.createFromAuthorizationCode(context, authorizationCode).getRefreshToken();
 	}
 }

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
@@ -410,6 +410,9 @@ public final class OAuthTokenCredential {
 			throw PayPalRESTException.createFromHttpErrorException(e);
 		} catch (Exception e) {
 			throw new PayPalRESTException(e.getMessage(), e);
+		} finally {
+			// Replace the headers back to JSON for any future use.
+			this.headers.put(Constants.HTTP_CONTENT_TYPE_HEADER, Constants.HTTP_CONTENT_TYPE_JSON);
 		}
 		return generatedToken;
 	}

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/PayPalResource.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/PayPalResource.java
@@ -256,8 +256,7 @@ public abstract class PayPalResource extends PayPalModel{
 		String requestId;
 		Map<String, String> headersMap;
 		if (apiContext != null) {
-			validateAPIContext(apiContext);
-			if (apiContext.getHTTPHeader(Constants.HTTP_CONTENT_TYPE_HEADER) != null) {
+			if (apiContext.getHTTPHeader(Constants.HTTP_CONTENT_TYPE_HEADER) == null) {
 				apiContext.addHTTPHeader(Constants.HTTP_CONTENT_TYPE_HEADER, Constants.HTTP_CONTENT_TYPE_JSON);
 			}
 			if (apiContext.getSdkVersion() != null) {
@@ -282,6 +281,10 @@ public abstract class PayPalResource extends PayPalModel{
 			if (accessToken == null) {
 				accessToken = apiContext.fetchAccessToken();
 			}
+			// If it is still null, throw the exception.
+			if (accessToken == null) {
+				throw new IllegalArgumentException("AccessToken cannot be null or empty");
+			}
 			requestId = apiContext.getRequestId();
 
 			APICallPreHandler apiCallPreHandler = createAPICallPreHandler(cMap,
@@ -292,15 +295,6 @@ public abstract class PayPalResource extends PayPalModel{
 			t = execute(apiCallPreHandler, httpConfiguration, clazz);
 		}
 		return t;
-	}
-
-	public static void validateAPIContext(APIContext context) throws PayPalRESTException {
-		if (context == null) {
-			throw new IllegalArgumentException("APIContext cannot be null");
-		}
-		if (context.fetchAccessToken() == null || context.fetchAccessToken().trim().length() <= 0) {
-			throw new IllegalArgumentException("AccessToken cannot be null or empty");
-		}
 	}
 
 	/**


### PR DESCRIPTION
- Uses APIContext instead of access token.
- Fixes #208.

# Create Token from Code
#### BEFORE
```java
    Map<String, String> configurationMap = new HashMap<String, String>();
    configurationMap.put(Constants.CLIENT_ID, "...");
    configurationMap.put(Constants.CLIENT_SECRET, "...");
    configurationMap.put(Constants.ENDPOINT, "https://api.paypal.com/");
    APIContext apiContext = new APIContext();
    apiContext.setConfigurationMap(configurationMap);
    ...
    CreateFromAuthorizationCodeParameters param = new CreateFromAuthorizationCodeParameters();
    param.setCode(code);
    Tokeninfo info = Tokeninfo.createFromAuthorizationCode(apiContext, param);
    String accessToken = info.getAccessToken();
```

#### AFTER
```java
    APIContext context = new APIContext(clientID, clientSecret, "sandbox");
    Tokeninfo info = Tokeninfo.createFromAuthorizationCode(context, code);
```
# Get User Info

#### BEFORE
```java
Map<String, String> configurationMap = new HashMap<String, String>();
    configurationMap.put(Constants.CLIENT_ID, "...");
    configurationMap.put(Constants.CLIENT_SECRET, "...");
    configurationMap.put(Constants.ENDPOINT, "https://api.paypal.com/");
    APIContext apiContext = new APIContext();
    apiContext.setConfigurationMap(configurationMap);
    ...
    Tokeninfo info = new Tokeninfo();
    info.setRefreshToken("refreshToken");
    UserinfoParameters param = new UserinfoParameters();
    param.setAccessToken(info.getAccessToken());
    Userinfo userInfo = Userinfo.userinfo(apiContext, param);
```

#### AFTER
```java
APIContext userAPIContext = new APIContext(clientID, clientSecret, "sandbox").setRefreshToken("<Refresh Token>");
Userinfo userinfo = Userinfo.getUserinfo(userAPIContext);
```