### PR TITLE
Changed cvv2 to be a String

### DIFF
--- a/rest-api-sdk/src/main/java/com/paypal/api/payments/CreditCard.java
+++ b/rest-api-sdk/src/main/java/com/paypal/api/payments/CreditCard.java
@@ -46,7 +46,8 @@ public class CreditCard  extends PayPalResource {
 	 * Card validation code. Only supported when making a Payment but not when saving a credit card for future use.
 	 */
 	@Getter(AccessLevel.NONE)
-	private Integer cvv2;
+	@Setter(AccessLevel.NONE)
+	private String cvv2;
 
 	/**
 	 * Card holder's first name.
@@ -96,6 +97,7 @@ public class CreditCard  extends PayPalResource {
 	}
 
 	/**
+	 * @deprecated Please use {@link #getCvv2String()} instead.
 	 * Getter for cvv2
 	 * Returns -1 if <code>cvv2</code> is null.
 	 * Not autogenerating using lombok as it includes logic to return -1 on null.
@@ -104,8 +106,35 @@ public class CreditCard  extends PayPalResource {
 		if (this.cvv2 == null) {
 			return -1;
 		} else {
-			return this.cvv2;
+			return Integer.valueOf(this.cvv2);
 		}
+	}
+
+	/**
+	 * @deprecated The cvv2 needs to be a string, as any cvv2 starting with 0 is sent invalid to servers. Please use {@link #setCvv2(String)} instead.
+	 * @param cvv2 Integer cvv2
+	 * @return CreditCard
+	 */
+	public CreditCard setCvv2(Integer cvv2) {
+		this.cvv2 = cvv2.toString();
+		return this;
+	}
+
+	/**
+	 * @param cvv2 String cvv2
+	 * @return CreditCard
+	 */
+	public CreditCard setCvv2(String cvv2) {
+		this.cvv2 = cvv2;
+		return this;
+	}
+
+	/**
+	 * Returns the cvv2
+	 * @return String representation of cvv2
+	 */
+	public String getCvv2String() {
+		return this.cvv2;
 	}
 	
 	/**

--- a/rest-api-sdk/src/test/java/com/paypal/api/payments/CreditCardTestCase.java
+++ b/rest-api-sdk/src/test/java/com/paypal/api/payments/CreditCardTestCase.java
@@ -33,7 +33,7 @@ public class CreditCardTestCase {
 
 	public static final int EXPYEAR = 2018;
 
-	public static final int CVV2 = 874;
+	public static final String CVV2 = "874";
 
 	public static final String ID = "12345";
 
@@ -80,7 +80,7 @@ public class CreditCardTestCase {
 	@Test(groups = "unit")
 	public void testConstruction() {
 		CreditCard creditCard = createDummyCreditCard();
-		Assert.assertEquals(creditCard.getCvv2(), CVV2);
+		Assert.assertEquals(creditCard.getCvv2String(), CVV2);
 		Assert.assertEquals(creditCard.getExpireMonth(), EXPMONTH);
 		Assert.assertEquals(creditCard.getExpireYear(), EXPYEAR);
 		Assert.assertEquals(creditCard.getFirstName(), FIRSTNAME);
@@ -103,12 +103,12 @@ public class CreditCardTestCase {
 		CreditCard creditCard = createDummyCreditCard();
 		
 		// empty CVV2
-		creditCard.setCvv2(null);
-		Assert.assertEquals(-1, creditCard.getCvv2());
+		creditCard.setCvv2("");
+		Assert.assertEquals("", creditCard.getCvv2String());
 		
 		// valid CVV2
 		creditCard.setCvv2(123);
-		Assert.assertEquals(123, creditCard.getCvv2());
+		Assert.assertEquals("123", creditCard.getCvv2String());
 	}
 
 	@Test(groups = "integration")

--- a/rest-api-sdk/src/test/java/com/paypal/api/payments/FundingInstrumentTestCase.java
+++ b/rest-api-sdk/src/test/java/com/paypal/api/payments/FundingInstrumentTestCase.java
@@ -23,7 +23,7 @@ public class FundingInstrumentTestCase {
 		FundingInstrument fundingInsturment = createFundingInstrument();
 		Assert.assertEquals(fundingInsturment.getCreditCardToken()
 				.getCreditCardId(), CreditCardTokenTestCase.CREDITCARDID);
-		Assert.assertEquals(fundingInsturment.getCreditCard().getCvv2(),
+		Assert.assertEquals(fundingInsturment.getCreditCard().getCvv2String(),
 				CreditCardTestCase.CVV2);
 	}
 


### PR DESCRIPTION
- Fixes #241.
- Deprecated `setCvv2(Integer cvv2)`.