### PR TITLE
Make `generateAccessToken` synchronized.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ release.sh
 
 # Maven specific #
 target/
+classes
 
 #################
 ## Visual Studio

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/APIContext.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/APIContext.java
@@ -299,11 +299,10 @@ public class APIContext {
 	 * @throws PayPalRESTException
 	 */
 	public String fetchAccessToken() throws PayPalRESTException {
-		String accessToken = null;
 		if (this.credential != null) {
-			accessToken = this.credential.getAccessToken();
+			return this.credential.getAccessToken();
 		}
-		return accessToken;
+		return null;
 	}
 
 	/**

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/AccessToken.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/AccessToken.java
@@ -1,0 +1,27 @@
+package com.paypal.base.rest;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+@Accessors(chain = true)
+public class AccessToken {
+
+    private String accessToken;
+    private long expires = 0;
+
+    /**
+     * Specifies how long this token can be used for placing API calls. The
+     * remaining lifetime is given in seconds.
+     *
+     * @return remaining lifetime of this access token in seconds
+     */
+    public long expiresIn() {
+        return expires - new java.util.Date().getTime() / 1000;
+    }
+
+}


### PR DESCRIPTION
- Fixes issue when concurrent threads tries to fetch new accessToken on
  expiry.