### PR TITLE
Fix Patch requests for Google App Engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ project(':rest-api-sdk') {
 
         // Test
         testCompile 'org.testng:testng:6.3.1'
+        testCompile "org.mockito:mockito-core:2.+"
     }
 
     test {

--- a/rest-api-sdk/src/main/java/com/paypal/base/GoogleAppEngineHttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/GoogleAppEngineHttpConnection.java
@@ -17,16 +17,16 @@ import java.util.HashMap;
 
 /**
  * A special HttpConnection for use on Google App Engine.
- * 
+ *
  * In order to activate this feature, set 'http.GoogleAppEngine = true' in the
  * SDK config file.
- * 
+ *
  */
 public class GoogleAppEngineHttpConnection extends HttpConnection {
 
 	private static final Logger log = LoggerFactory.getLogger(GoogleAppEngineHttpConnection.class);
 
-  private String requestMethod = null;
+	private String requestMethod = null;
 
 	@Override
 	public void setupClientSSL(String certPath, String certKey)
@@ -66,10 +66,10 @@ public class GoogleAppEngineHttpConnection extends HttpConnection {
 
 		if ("PATCH".equals(config.getHttpMethod().toUpperCase())) {
 			this.connection.setRequestMethod("POST");
-      this.requestMethod = "PATCH";
-		} else { 
-		  this.connection.setRequestMethod(config.getHttpMethod());
-    }
+			this.requestMethod = "PATCH";
+		} else {
+			this.connection.setRequestMethod(config.getHttpMethod());
+		}
 		this.connection.setConnectTimeout(this.config.getConnectionTimeout());
 		this.connection.setReadTimeout(this.config.getReadTimeout());
 	}

--- a/rest-api-sdk/src/main/java/com/paypal/base/GoogleAppEngineHttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/GoogleAppEngineHttpConnection.java
@@ -1,13 +1,19 @@
 package com.paypal.base;
 
 import com.paypal.base.exception.SSLConfigurationException;
+import com.paypal.base.exception.HttpErrorException;
+import com.paypal.base.exception.InvalidResponseDataException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
 import java.net.URL;
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * A special HttpConnection for use on Google App Engine.
@@ -19,6 +25,8 @@ import java.net.URL;
 public class GoogleAppEngineHttpConnection extends HttpConnection {
 
 	private static final Logger log = LoggerFactory.getLogger(GoogleAppEngineHttpConnection.class);
+
+  private String requestMethod = null;
 
 	@Override
 	public void setupClientSSL(String certPath, String certKey)
@@ -55,9 +63,27 @@ public class GoogleAppEngineHttpConnection extends HttpConnection {
 				.openConnection(Proxy.NO_PROXY);
 		this.connection.setDoInput(true);
 		this.connection.setDoOutput(true);
-		this.connection.setRequestMethod(config.getHttpMethod());
+
+		if ("PATCH".equals(config.getHttpMethod().toUpperCase())) {
+			this.connection.setRequestMethod("POST");
+      this.requestMethod = "PATCH";
+		} else { 
+		  this.connection.setRequestMethod(config.getHttpMethod());
+    }
 		this.connection.setConnectTimeout(this.config.getConnectionTimeout());
 		this.connection.setReadTimeout(this.config.getReadTimeout());
 	}
 
+	@Override
+	public InputStream executeWithStream(String url, String payload,
+			Map<String, String> headers) throws InvalidResponseDataException,
+			IOException, InterruptedException, HttpErrorException {
+
+		Map<String, String> headersCopy = new HashMap<String, String>(headers);
+		if (requestMethod != null) {
+			headersCopy.put("X-HTTP-Method-Override", requestMethod);
+		}
+
+		return super.executeWithStream(url, payload, headersCopy);
+	}
 }

--- a/rest-api-sdk/src/test/java/com/paypal/base/GoogleAppEngineHttpConnectionTest.java
+++ b/rest-api-sdk/src/test/java/com/paypal/base/GoogleAppEngineHttpConnectionTest.java
@@ -1,26 +1,26 @@
 package com.paypal.base;
 
-import java.net.MalformedURLException;
-
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import com.paypal.base.exception.HttpErrorException;
+import com.paypal.base.exception.InvalidResponseDataException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.HashMap;
+
+import static org.mockito.Mockito.*;
 
 public class GoogleAppEngineHttpConnectionTest {
 
 	GoogleAppEngineHttpConnection googleAppEngineHttpConnection;
 	HttpConfiguration httpConfiguration;
 
-	@BeforeClass
-	public void beforeClass() {
+	@BeforeMethod
+	public void setup() {
 		googleAppEngineHttpConnection = new GoogleAppEngineHttpConnection();
 		httpConfiguration = new HttpConfiguration();
-	}
-
-	@AfterClass
-	public void afterClass() {
-		googleAppEngineHttpConnection = null;
-		httpConfiguration = null;
 	}
 
 	@Test(expectedExceptions = MalformedURLException.class)
@@ -30,4 +30,31 @@ public class GoogleAppEngineHttpConnectionTest {
 				.createAndconfigureHttpConnection(httpConfiguration);
 	}
 
+	@Test
+	public void testCreateAndConfigureHttpConnection_setsRequestMethodToPost() throws IOException {
+		httpConfiguration.setEndPointUrl("http://www.paypal.com");
+		httpConfiguration.setHttpMethod("PATCH");
+		GoogleAppEngineHttpConnection googleAppEngineHttpConnection = spy(GoogleAppEngineHttpConnection.class);
+		doCallRealMethod().when(googleAppEngineHttpConnection).createAndconfigureHttpConnection((HttpConfiguration) any());
+		googleAppEngineHttpConnection.createAndconfigureHttpConnection(httpConfiguration);
+		Assert.assertEquals("POST", googleAppEngineHttpConnection.connection.getRequestMethod());
+	}
+
+	@Test
+	public void testExecuteWithStream_usesPostInsteadOfPatchAndAddsOverrideHeader() throws InterruptedException, HttpErrorException, InvalidResponseDataException, IOException {
+		httpConfiguration.setEndPointUrl("http://www.paypal.com");
+		httpConfiguration.setHttpMethod("PATCH");
+		GoogleAppEngineHttpConnection googleAppEngineHttpConnection = spy(GoogleAppEngineHttpConnection.class);
+		doCallRealMethod().when(googleAppEngineHttpConnection).createAndconfigureHttpConnection((HttpConfiguration) any());
+		try {
+			googleAppEngineHttpConnection.createAndconfigureHttpConnection(httpConfiguration);
+			googleAppEngineHttpConnection.executeWithStream(null, "payload", new HashMap<String, String>());
+		} catch (Exception ex) {
+			// Do nothing
+		}
+		verify(googleAppEngineHttpConnection).setHttpHeaders(new HashMap<String, String>() {{
+			put("X-HTTP-Method-Override", "PATCH");
+		}});
+		Assert.assertEquals("POST", googleAppEngineHttpConnection.connection.getRequestMethod());
+	}
 }


### PR DESCRIPTION
- Enables Google App Engine to work with `PATCH` requests.
- Fixes #262.