### PR TITLE
Use service.Endpoint if set in configurations over `mode` values

### DIFF
--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
@@ -443,7 +443,7 @@ public final class OAuthTokenCredential {
 	/*
 	 * Get HttpConfiguration object for OAuth server
 	 */
-	private HttpConfiguration getOAuthHttpConfiguration() throws MalformedURLException {
+	protected HttpConfiguration getOAuthHttpConfiguration() throws MalformedURLException {
 		HttpConfiguration httpConfiguration = new HttpConfiguration();
 		httpConfiguration
 				.setHttpMethod(Constants.HTTP_CONFIG_DEFAULT_HTTP_METHOD);
@@ -457,18 +457,20 @@ public final class OAuthTokenCredential {
 		String mode = this.configurationMap.get(Constants.MODE);
 		// Default to Endpoint param.
 		String endPointUrl = this.configurationMap.get(Constants.OAUTH_ENDPOINT);
-		if (Constants.SANDBOX.equalsIgnoreCase(mode)) {
-			endPointUrl = Constants.REST_SANDBOX_ENDPOINT;
-		} else if (Constants.LIVE.equalsIgnoreCase(mode)) {
-			endPointUrl = Constants.REST_LIVE_ENDPOINT;
-		} else if (endPointUrl == null || endPointUrl.length() <= 0) {
-			// Default to Normal endpoint
-			endPointUrl = this.configurationMap.get(Constants.ENDPOINT);
-		} 
+		if (endPointUrl == null || endPointUrl.trim().isEmpty()) {
+			if (Constants.SANDBOX.equalsIgnoreCase(mode)) {
+				endPointUrl = Constants.REST_SANDBOX_ENDPOINT;
+			} else if (Constants.LIVE.equalsIgnoreCase(mode)) {
+				endPointUrl = Constants.REST_LIVE_ENDPOINT;
+			} else if (endPointUrl == null || endPointUrl.length() <= 0) {
+				// Default to Normal endpoint
+				endPointUrl = this.configurationMap.get(Constants.ENDPOINT);
+			}
+		}
 		// If none of the option works, throw exception.
 		if (endPointUrl == null || endPointUrl.length() <= 0) {
 			throw new MalformedURLException(
-					"service.EndPoint not set (OR) mode not configured to sandbox/live ");
+					"oauth.Endpoint, mode or service.EndPoint not set not configured to sandbox/live ");
 		}
 		
 		if (Boolean

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
@@ -468,7 +468,7 @@ public final class OAuthTokenCredential {
 			}
 		}
 		// If none of the option works, throw exception.
-		if (endPointUrl == null || endPointUrl.length() <= 0) {
+		if (endPointUrl == null || endPointUrl.trim().length() <= 0) {
 			throw new MalformedURLException(
 					"oauth.Endpoint, mode or service.EndPoint not set not configured to sandbox/live ");
 		}

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/OAuthTokenCredential.java
@@ -454,7 +454,7 @@ public final class OAuthTokenCredential {
 		 * endpoint to PayPal sandbox or live endpoints. Throw exception if the
 		 * above rules fail
 		 */
-		String mode = this.configurationMap.get(Constants.MODE);
+		final String mode = this.configurationMap.get(Constants.MODE);
 		// Default to Endpoint param.
 		String endPointUrl = this.configurationMap.get(Constants.OAUTH_ENDPOINT);
 		if (endPointUrl == null || endPointUrl.trim().isEmpty()) {

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/RESTAPICallPreHandler.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/RESTAPICallPreHandler.java
@@ -208,11 +208,15 @@ public class RESTAPICallPreHandler implements APICallPreHandler {
 					urlString = Constants.REST_SANDBOX_ENDPOINT;
 				} else if (Constants.LIVE.equalsIgnoreCase(mode)) {
 					urlString = Constants.REST_LIVE_ENDPOINT;
-				} else if (urlString == null || urlString.length() <= 0) {
-					throw new MalformedURLException(
-							"service.EndPoint not set (OR) mode not configured to sandbox/live ");
 				}
 			}
+
+			// If none of the option works, throw exception.
+			if (urlString == null || urlString.trim().length() <= 0) {
+				throw new MalformedURLException(
+						"service.EndPoint not set (OR) mode not configured to sandbox/live ");
+			}
+
 			if (!urlString.endsWith("/")) {
 				urlString += "/";
 			}

--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/RESTAPICallPreHandler.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/RESTAPICallPreHandler.java
@@ -203,13 +203,15 @@ public class RESTAPICallPreHandler implements APICallPreHandler {
 			String mode = this.configurationMap.get(Constants.MODE);
 			// Default to Endpoint param.
 			String urlString = this.configurationMap.get(Constants.ENDPOINT);
-			if (Constants.SANDBOX.equalsIgnoreCase(mode)) {
-				urlString = Constants.REST_SANDBOX_ENDPOINT;
-			} else if (Constants.LIVE.equalsIgnoreCase(mode)) {
-				urlString = Constants.REST_LIVE_ENDPOINT;
-			} else if (urlString == null || urlString.length() <= 0) {
-				throw new MalformedURLException(
-						"service.EndPoint not set (OR) mode not configured to sandbox/live ");
+			if (urlString == null || urlString.trim().isEmpty()) {
+				if (Constants.SANDBOX.equalsIgnoreCase(mode)) {
+					urlString = Constants.REST_SANDBOX_ENDPOINT;
+				} else if (Constants.LIVE.equalsIgnoreCase(mode)) {
+					urlString = Constants.REST_LIVE_ENDPOINT;
+				} else if (urlString == null || urlString.length() <= 0) {
+					throw new MalformedURLException(
+							"service.EndPoint not set (OR) mode not configured to sandbox/live ");
+				}
 			}
 			if (!urlString.endsWith("/")) {
 				urlString += "/";

--- a/rest-api-sdk/src/test/java/com/paypal/base/rest/OAuthTokenCredentialTestCase.java
+++ b/rest-api-sdk/src/test/java/com/paypal/base/rest/OAuthTokenCredentialTestCase.java
@@ -1,14 +1,20 @@
 package com.paypal.base.rest;
 
+import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.paypal.base.Constants;
+import com.paypal.base.HttpConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
 
 import com.paypal.base.exception.HttpErrorException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 public class OAuthTokenCredentialTestCase {
 
@@ -49,6 +55,32 @@ public class OAuthTokenCredentialTestCase {
 		} catch (PayPalRESTException e) {
 			Assert.assertEquals(true, e.getCause() instanceof HttpErrorException);
 		}
+	}
+
+	@Test
+	public void getOAuthHttpConfiguration_returnsServiceEndpointIfSet() throws MalformedURLException {
+		Map<String, String> configurationMap = new HashMap<String, String>();
+		configurationMap.put(Constants.OAUTH_ENDPOINT,
+				"https://oauth.example.com/abc");
+
+		HttpConfiguration result = new OAuthTokenCredential("abc", "def", configurationMap).getOAuthHttpConfiguration();
+		assertNotNull(result);
+		assertEquals(result.getEndPointUrl(), "https://oauth.example.com/abc/v1/oauth2/token");
+	}
+
+	@Test
+	public void getOAuthHttpConfiguration_usesModeEndpointIfServiceEndpointNotSet() throws MalformedURLException {
+		Map<String, String> configurationMap = new HashMap<String, String>();
+		configurationMap.put(Constants.MODE, "sandbox");
+
+		HttpConfiguration result = new OAuthTokenCredential("abc", "def", configurationMap).getOAuthHttpConfiguration();
+		assertNotNull(result);
+		assertEquals(result.getEndPointUrl(), "https://api.sandbox.paypal.com/v1/oauth2/token");
+	}
+
+	@Test(expectedExceptions = MalformedURLException.class, expectedExceptionsMessageRegExp = "oauth\\.Endpoint, mode or service\\.EndPoint not set not configured to sandbox\\/live ")
+	public void getOAuthHttpConfiguration_throwsExceptionIfBothModeAndServiceEndpointNotSet() throws MalformedURLException {
+		new OAuthTokenCredential("abc", "def", new HashMap<String, String>()).getOAuthHttpConfiguration();
 	}
 
 }

--- a/rest-api-sdk/src/test/java/com/paypal/base/rest/RESTAPICallPreHandlerTest.java
+++ b/rest-api-sdk/src/test/java/com/paypal/base/rest/RESTAPICallPreHandlerTest.java
@@ -1,0 +1,50 @@
+package com.paypal.base.rest;
+
+import com.paypal.base.Constants;
+import org.testng.annotations.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class RESTAPICallPreHandlerTest {
+
+    @Test
+    public void getBaseURL_returnsServiceEndpointIfSet() throws MalformedURLException {
+        Map<String, String> configurations = new HashMap<String, String>();
+        configurations.put(Constants.ENDPOINT, "https://www.example.com/abc");
+        RESTAPICallPreHandler restapiCallPreHandler = new RESTAPICallPreHandler(configurations);
+
+        URL result = restapiCallPreHandler.getBaseURL();
+
+        assertNotNull(result);
+        assertEquals(result.getHost(), "www.example.com");
+        assertEquals(result.getPath(), "/abc/");
+    }
+
+    @Test
+    public void getBaseURL_usesModeEndpointIfServiceEndpointNotSet() throws MalformedURLException {
+        Map<String, String> configurations = new HashMap<String, String>();
+        configurations.put(Constants.MODE, "sandbox");
+        RESTAPICallPreHandler restapiCallPreHandler = new RESTAPICallPreHandler(configurations);
+
+        URL result = restapiCallPreHandler.getBaseURL();
+
+        assertNotNull(result);
+        assertEquals(result.getHost(), "api.sandbox.paypal.com");
+        assertEquals(result.getPath(), "/");
+    }
+
+    @Test(expectedExceptions = MalformedURLException.class, expectedExceptionsMessageRegExp = "service\\.EndPoint not set \\(OR\\) mode not configured to sandbox\\/live ")
+    public void getBaseURL_throwsExceptionIfBothModeAndServiceEndpointNotSet() throws MalformedURLException {
+        Map<String, String> configurations = new HashMap<String, String>();
+        RESTAPICallPreHandler restapiCallPreHandler = new RESTAPICallPreHandler(configurations);
+
+        restapiCallPreHandler.getBaseURL();
+    }
+
+}


### PR DESCRIPTION
Originally, passing `service.Endpoint` configuration along with `mode` should use `service.Endpoint` url for all API calls. However, it does not. This bug fixes that.

- Fixes #293 

@derarmin
@paypal/dx-team 