### PR TITLE
296 update jetty gretty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,7 @@ rest-api-sdk/test-output/
 # Gradle
 .gradle
 build/
+gradle.properties
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
+        classpath 'org.akhikhl.gretty:gretty:1.4.2'
     }
 }
 apply plugin: 'io.codearte.nexus-staging'
@@ -149,7 +150,7 @@ project(':rest-api-sdk') {
 
 // ## REST API SAMPLE PROJECT
 project(':rest-api-sample') {
-    apply plugin: 'jetty'
+    apply plugin: 'org.akhikhl.gretty'
 
     dependencies {
         compile project(':rest-api-sdk')

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,9 @@ project(':rest-api-sdk') {
 project(':rest-api-sample') {
     apply plugin: 'org.akhikhl.gretty'
 
+    // property name to override default Jetty port
+    final JETTY_RUN_HTTP_PORT = 'jettyRunHttpPort'
+
     dependencies {
         compile project(':rest-api-sdk')
         compile 'javax.servlet:javax.servlet-api:3.1.0'
@@ -160,4 +163,27 @@ project(':rest-api-sample') {
         compile 'org.apache.logging.log4j:log4j-core:2.1'
         compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.1'
     }
+
+    gretty.httpPort = Integer.valueOf(findPropertyOrDefault(JETTY_RUN_HTTP_PORT, project, 8080))
+}
+
+/**
+ * Try to find first significant value by {@code propertyName} in the next order:
+ * <ol>
+ *   <li>If {@code propertyName} is supplied as a gradle runtime argument (<b>-D</b> option)</li>
+ *   <li>If {@code propertyName} is set as a {@code project} property, for example in
+ *       {@code gradle.properties} file of the project or in the gradle home directory</li>
+ *   <li>otherwise fallback to {@code defaultValue}</li>
+ * </ol>
+ *
+ * @param propertyName name of the sought property
+ * @param project Gradle project in which try to find the value
+ * @param defaultValue value to use if neither runtime argument nor project property found
+ *
+ * @return String value from system, project property, or {@code defaultValue}
+ */
+static String findPropertyOrDefault(String propertyName, Project project, Object defaultValue) {
+    return System.getProperty(propertyName) ?:
+        project.findProperty(propertyName) ?:
+            defaultValue as String
 }

--- a/rest-api-sample/README.md
+++ b/rest-api-sample/README.md
@@ -3,11 +3,20 @@ REST API Samples
 
 This project contains a set of samples that you can explore to understand what the REST APIs can do for you. The sample comes pre-configured with a test account but in case you need to try them against your account, you must obtain your client id and client secret from the developer portal.
 
-Build and run the samples
---------------------------
+Build, run and debug the samples
+--------------------------------
 
   * Simply run `./gradlew clean jettyRun` to start jetty server.
+    * Run `./gradlew clean jettyRunDebug` to start jetty server in debug mode.
+    See [Debugger support](http://akhikhl.github.io/gretty-doc/Debugger-support.html)
+    and [Gretty tasks](http://akhikhl.github.io/gretty-doc/Gretty-tasks) for more info.
+
   * Access `http://localhost:<jetty-port>/rest-api-sample/` in your browser to view samples.
+    * to assign a custom port for _Jetty_ server set gradle project property
+    `jettyRunHttpPort` (in your custom `gradle.properties` file) or run
+    the build gradle command with `-DjettyRunHttpPort` java argument:
+
+      `./gradlew clean jettyRunDebug -DjettyRunHttpPort=9090`
 
 Test Account
 ------------


### PR DESCRIPTION
Fix for issue #296:
  
  - replace default Jetty to [Gretty plugin](https://github.com/akhikhl/gretty) as it is recommended by [gradle documentation](https://docs.gradle.org/3.3/userguide/jetty_plugin.html)
  
  - make Jetty application port port configurable over `gradle.properties` or gradle run java arguments.