### PR TITLE
curl log enhancement

### DIFF
--- a/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
@@ -209,18 +209,18 @@ public abstract class HttpConnection {
      */
 	private void logCurlRequest(String payload, Map<String, String> headers) {
 		StringBuilder cmdBuilder = new StringBuilder("curl command: \n");
-		cmdBuilder.append("curl -v");
-		cmdBuilder.append(" -X ").append(connection.getRequestMethod().toUpperCase());
+		cmdBuilder.append("curl --verbose");
+		cmdBuilder.append(" --request ").append(connection.getRequestMethod().toUpperCase());
 		cmdBuilder.append(" '").append(connection.getURL().toString()).append("'");
 
 		if (headers != null) {
 			for (String key : headers.keySet()) {
 				String value = headers.get(key);
-				cmdBuilder.append(String.format(" \\\n  -H \"%s:%s\"", key, value));
+				cmdBuilder.append(String.format(" \\\n  --header \"%s:%s\"", key, value));
 			}
 		}
 
-		cmdBuilder.append(String.format(" \\\n  -d '%s'", payload));
+		cmdBuilder.append(String.format(" \\\n  --data '%s'", payload));
 
 		log.debug(cmdBuilder.toString());
 	}

--- a/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
@@ -208,18 +208,21 @@ public abstract class HttpConnection {
 	 * @param headers Headers Map
      */
 	private void logCurlRequest(String payload, Map<String, String> headers) {
-		String cmd = "curl command: \n";
-		cmd += "curl -v ";
-		cmd += "-X " + connection.getRequestMethod().toUpperCase();
-		cmd += " '" + connection.getURL().toString() + "' \\\n";
+		StringBuilder cmdBuilder = new StringBuilder("curl command: \n");
+		cmdBuilder.append("curl -v");
+		cmdBuilder.append(" -X ").append(connection.getRequestMethod().toUpperCase());
+		cmdBuilder.append(" '").append(connection.getURL().toString()).append("'");
+
 		if (headers != null) {
 			for (String key : headers.keySet()) {
 				String value = headers.get(key);
-				cmd += "-H \"" + key + ": " + value + "\" \\\n";
+				cmdBuilder.append(String.format(" \\\n  -H \"%s:%s\"", key, value));
 			}
 		}
-		cmd += "-d '" + payload + "'";
-		log.debug(cmd);
+
+		cmdBuilder.append(String.format(" \\\n  -d '%s'", payload));
+
+		log.debug(cmdBuilder.toString());
 	}
 
 	/**

--- a/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
@@ -209,7 +209,9 @@ public abstract class HttpConnection {
      */
 	private void logCurlRequest(String payload, Map<String, String> headers) {
 		String cmd = "curl command: \n";
-		cmd += "curl -v '" + connection.getURL().toString() + "' \\\n";
+		cmd += "curl -v ";
+		cmd += "-X " + connection.getRequestMethod().toUpperCase();
+		cmd += " '" + connection.getURL().toString() + "' \\\n";
 		if (headers != null) {
 			for (String key : headers.keySet()) {
 				String value = headers.get(key);


### PR DESCRIPTION
In addition to my previous PR https://github.com/paypal/PayPal-Java-SDK/pull/299 

(**Note:** unfortunately, i it's impossible to create a PR based on a branch in my fork until you accept the PR/merge it, so basically this fix expects to apply #299 first, then this PR could be updated on top of it)

Propositions:
  * Use `StringBuilder` instead of strings concatenation, as this is recommended Java style
  * Use full `curl` argument names, like: `--request` instead of `-X`, `--head` instead of `-H` and so on. 
  Since it is automatically built command line i propose to use these full names as they are more readable and easier to understand when a consumer reads the logs and ties to understand what exactly is sent to the server.