### PR TITLE
Undeprecate PaymentInstruction with note for German merchants only

### DIFF
--- a/rest-api-sdk/src/main/java/com/paypal/api/payments/Payment.java
+++ b/rest-api-sdk/src/main/java/com/paypal/api/payments/Payment.java
@@ -65,7 +65,7 @@ public class Payment extends PayPalResource {
 	private CreditFinancingOffered creditFinancingOffered;
 
 	/**
-	 * Instructions for the payer to complete this payment.
+	 * Instructions for the payer to complete this payment. Applies to the German market and partners only.
 	 */
 	private PaymentInstruction paymentInstruction;
 
@@ -105,7 +105,7 @@ public class Payment extends PayPalResource {
 	private String updateTime;
 
 	/**
-	 * 
+	 *
 	 */
 	private List<Links> links;
 

--- a/rest-api-sdk/src/main/java/com/paypal/api/payments/PaymentInstruction.java
+++ b/rest-api-sdk/src/main/java/com/paypal/api/payments/PaymentInstruction.java
@@ -7,10 +7,6 @@ import lombok.Getter; import lombok.Setter;
 
 import java.util.List;
 
-/**
- * @deprecated PaymentInstruction object is not available for public use.
- */
-
 @Getter @Setter
 @EqualsAndHashCode(callSuper = true)
 @Accessors(chain = true)
@@ -47,7 +43,7 @@ public class PaymentInstruction extends PayPalResource {
 	private String note;
 
 	/**
-	 * 
+	 *
 	 */
 	private List<Links> links;
 


### PR DESCRIPTION
PaymentInstrument is available for limited release, however, it is open for all German merchants.

- Fixes #313 