### PR TITLE
payment item quantity is an integer

### DIFF
--- a/paypal-sdk/src/main/java/com/paypal/sdk/v1/payments/Item.java
+++ b/paypal-sdk/src/main/java/com/paypal/sdk/v1/payments/Item.java
@@ -79,11 +79,11 @@ public class Item {
 	* The item quantity. Must be a whole number.
 	*/
 	@SerializedName("quantity")
-	private String quantity;
+	private int quantity;
 
-	public String quantity() { return quantity; }
+	public int quantity() { return quantity; }
 	
-	public Item quantity(String quantity) {
+	public Item quantity(int quantity) {
 	    this.quantity = quantity;
 	    return this;
 	}


### PR DESCRIPTION
The JSON returned from Paypal contains the item line quantity as an integer. This leads to an exception in the Braintree JSON deserializer because com.paypal.sdk.v1.payments.Item#quantity is a string. Changing this to int solves the issue. Something similar might be neccessary for order.Item but I do not have a test scenario there.